### PR TITLE
chore: Fix new arch message serialization by adding 'isMainFrame' property to the data structure in iOS implementation.

### DIFF
--- a/.changeset/few-ghosts-enjoy.md
+++ b/.changeset/few-ghosts-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@phantom/react-native-webview': patch
+---
+
+Add isMainFrame to new arch serialization layer

--- a/apple/RNCWebView.mm
+++ b/apple/RNCWebView.mm
@@ -134,7 +134,8 @@ auto stringToOnLoadingFinishNavigationTypeEnum(std::string value) {
                     .canGoBack = static_cast<bool>([[dictionary valueForKey:@"canGoBack"] boolValue]),
                     .canGoForward = static_cast<bool>([[dictionary valueForKey:@"canGoForward"] boolValue]),
                     .loading = static_cast<bool>([[dictionary valueForKey:@"loading"] boolValue]),
-                    .data = std::string([[dictionary valueForKey:@"data"] UTF8String])
+                    .data = std::string([[dictionary valueForKey:@"data"] UTF8String]),
+                    .isMainFrame = static_cast<bool>([[dictionary valueForKey:@"isMainFrame"] boolValue])
                 };
                 webViewEventEmitter->onMessage(data);
             }


### PR DESCRIPTION
We were dropping the isMainFrame message attribute when using RN New Arch