### PR TITLE
feat(android): honor mediaCapturePermissionGrantType="deny" (AGE-378)

### DIFF
--- a/.changeset/age-378-android-deny-media-capture.md
+++ b/.changeset/age-378-android-deny-media-capture.md
@@ -1,0 +1,10 @@
+---
+"@phantom/react-native-webview": patch
+---
+
+Honor `mediaCapturePermissionGrantType="deny"` on Android. Previously the Android
+setter was a no-op and the value was ignored. Now `RNCWebChromeClient.onPermissionRequest`
+short-circuits and calls `request.deny()` before reading the requested resources, showing
+the site-attributed `AlertDialog`, or triggering an OS CAMERA/RECORD_AUDIO permission
+request. Other grant-type values (and the default `prompt`) preserve the existing Android
+prompt behavior, and iOS behavior is unchanged.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -86,6 +86,15 @@ android {
             }
         }
     }
+
+    testOptions {
+        unitTests {
+            // Allow referencing android.* classes from JVM unit tests; the
+            // RNCWebChromeClient permission tests mock everything they touch.
+            returnDefaultValues = true
+            includeAndroidResources = true
+        }
+    }
 }
 
 def reactNativePath = findNodeModulePath(projectDir, "react-native")
@@ -107,4 +116,7 @@ dependencies {
     implementation 'com.facebook.react:react-native:+'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${safeExtGet('kotlinVersion')}"
     implementation "androidx.webkit:webkit:${safeExtGet('webkitVersion')}"
+
+    testImplementation "junit:junit:4.13.2"
+    testImplementation "org.mockito:mockito-core:5.11.0"
 }

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java
@@ -91,6 +91,12 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
     protected RNCWebView.ProgressChangedFilter progressChangedFilter = null;
     protected boolean mAllowsProtectedMedia = false;
 
+    // Mirrors the iOS `mediaCapturePermissionGrantType` prop. Only the `deny`
+    // value is enforced natively on Android for now; any other value (including
+    // null) preserves the existing prompt behavior.
+    protected static final String MEDIA_CAPTURE_GRANT_TYPE_DENY = "deny";
+    protected String mMediaCapturePermissionGrantType = null;
+
     protected boolean mHasOnOpenWindowEvent = false;
 
     public RNCWebChromeClient(RNCWebView webView) {
@@ -156,6 +162,15 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
 
     @Override
     public void onPermissionRequest(final PermissionRequest request) {
+        // Honor `mediaCapturePermissionGrantType="deny"` before touching the
+        // requested resources, showing a site-attributed AlertDialog, or asking
+        // the OS for CAMERA/RECORD_AUDIO. This guarantees the dApp browser can
+        // never trigger a trusted-shell media-capture prompt.
+        if (MEDIA_CAPTURE_GRANT_TYPE_DENY.equals(mMediaCapturePermissionGrantType)) {
+            request.deny();
+            return;
+        }
+
         permissionRequest = request;
         grantedPermissions = new ArrayList<>();
         alertPermissions = new ArrayList<>();
@@ -476,6 +491,15 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
      */
     public void setAllowsProtectedMedia(boolean enabled) {
       mAllowsProtectedMedia = enabled;
+    }
+
+    /**
+     * Set how media-capture permission requests should be handled.
+     * Only the `deny` value is enforced natively on Android; any other value
+     * (including null) preserves the existing prompt behavior.
+     */
+    public void setMediaCapturePermissionGrantType(String value) {
+      mMediaCapturePermissionGrantType = value;
     }
 
     public void setHasOnOpenWindowEvent(boolean hasEvent) {

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
@@ -40,6 +40,7 @@ class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
     private var mWebViewConfig: RNCWebViewConfig = RNCWebViewConfig { webView: WebView? -> }
     private var mAllowsFullscreenVideo = false
     private var mAllowsProtectedMedia = false
+    private var mMediaCapturePermissionGrantType: String? = null
     private var mDownloadingMessage: String? = null
     private var mLackPermissionToDownloadMessage: String? = null
     private var mHasOnOpenWindowEvent = false
@@ -167,6 +168,7 @@ class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
                     }
                 }
             webChromeClient.setAllowsProtectedMedia(mAllowsProtectedMedia);
+            webChromeClient.setMediaCapturePermissionGrantType(mMediaCapturePermissionGrantType);
             webChromeClient.setHasOnOpenWindowEvent(mHasOnOpenWindowEvent);
             webView.webChromeClient = webChromeClient
         } else {
@@ -178,6 +180,7 @@ class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
                 }
             }
             webChromeClient.setAllowsProtectedMedia(mAllowsProtectedMedia);
+            webChromeClient.setMediaCapturePermissionGrantType(mMediaCapturePermissionGrantType);
             webChromeClient.setHasOnOpenWindowEvent(mHasOnOpenWindowEvent);
             webView.webChromeClient = webChromeClient
         }
@@ -608,6 +611,17 @@ class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
         if (client != null && client is RNCWebChromeClient) {
           client.setAllowsProtectedMedia(enabled)
         }
+      }
+    }
+
+    fun setMediaCapturePermissionGrantType(viewWrapper: RNCWebViewWrapper, value: String?) {
+      val view = viewWrapper.webView
+      // Keep the value so it survives recreation of the WebChromeClient
+      // (eg. when mAllowsFullScreenVideo changes).
+      mMediaCapturePermissionGrantType = value
+      val client = view.webChromeClient
+      if (client != null && client is RNCWebChromeClient) {
+        client.setMediaCapturePermissionGrantType(value)
       }
     }
 

--- a/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -95,6 +95,12 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
     }
 
     @Override
+    @ReactProp(name = "mediaCapturePermissionGrantType")
+    public void setMediaCapturePermissionGrantType(RNCWebViewWrapper view, @Nullable String value) {
+        mRNCWebViewManagerImpl.setMediaCapturePermissionGrantType(view, value);
+    }
+
+    @Override
     @ReactProp(name = "androidLayerType")
     public void setAndroidLayerType(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setAndroidLayerType(view, value);
@@ -422,9 +428,6 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
 
     @Override
     public void setHasOnFileDownload(RNCWebViewWrapper view, boolean value) {}
-
-    @Override
-    public void setMediaCapturePermissionGrantType(RNCWebViewWrapper view, @Nullable String value) {}
 
     @Override
     public void setFraudulentWebsiteWarningEnabled(RNCWebViewWrapper view, boolean value) {}

--- a/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -72,6 +72,11 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper> {
         mRNCWebViewManagerImpl.setAllowsProtectedMedia(view, value);
     }
 
+    @ReactProp(name = "mediaCapturePermissionGrantType")
+    public void setMediaCapturePermissionGrantType(RNCWebViewWrapper view, @Nullable String value) {
+        mRNCWebViewManagerImpl.setMediaCapturePermissionGrantType(view, value);
+    }
+
     @ReactProp(name = "androidLayerType")
     public void setAndroidLayerType(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setAndroidLayerType(view, value);

--- a/android/src/test/java/com/reactnativecommunity/webview/RNCWebChromeClientTest.java
+++ b/android/src/test/java/com/reactnativecommunity/webview/RNCWebChromeClientTest.java
@@ -1,0 +1,68 @@
+package com.reactnativecommunity.webview;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.webkit.PermissionRequest;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link RNCWebChromeClient#onPermissionRequest(PermissionRequest)} covering the
+ * Android enforcement of the {@code mediaCapturePermissionGrantType="deny"} prop.
+ */
+public class RNCWebChromeClientTest {
+
+  private RNCWebChromeClient createClient() {
+    RNCWebView webView = mock(RNCWebView.class);
+    return new RNCWebChromeClient(webView);
+  }
+
+  @Test
+  public void denyShortCircuitsPermissionRequest() {
+    RNCWebChromeClient client = createClient();
+    client.setMediaCapturePermissionGrantType("deny");
+
+    PermissionRequest request = mock(PermissionRequest.class);
+    client.onPermissionRequest(request);
+
+    // The request is denied immediately...
+    verify(request, times(1)).deny();
+    // ...and never reaches the resource-mapping / OS-permission / AlertDialog path,
+    // which always starts by reading the requested resources.
+    verify(request, never()).getResources();
+    verify(request, never()).grant(org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  public void nullGrantTypePreservesExistingPromptFlow() {
+    RNCWebChromeClient client = createClient();
+    // No grant type configured (default behavior).
+
+    PermissionRequest request = mock(PermissionRequest.class);
+    when(request.getResources()).thenReturn(new String[] {});
+
+    client.onPermissionRequest(request);
+
+    // It does NOT take the deny short-circuit: the existing flow always inspects
+    // the requested resources first.
+    verify(request, times(1)).getResources();
+  }
+
+  @Test
+  public void unknownGrantTypePreservesExistingPromptFlow() {
+    RNCWebChromeClient client = createClient();
+    // An unsupported value must preserve existing prompt behavior, not deny.
+    client.setMediaCapturePermissionGrantType("grant");
+
+    PermissionRequest request = mock(PermissionRequest.class);
+    when(request.getResources()).thenReturn(new String[] {});
+
+    client.onPermissionRequest(request);
+
+    verify(request, times(1)).getResources();
+  }
+}

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -1537,9 +1537,11 @@ Possible values:
 
 Note that a grant may still result in a prompt, for example if the user has never been prompted for the permission before.
 
-| Type   | Required | Platform |
-| ------ | -------- | -------- |
-| string | No       | iOS      |
+On Android, only the `deny` value is enforced natively: when set, camera/microphone requests are denied immediately without showing a prompt or triggering an OS permission dialog. Any other value (including the default `prompt`) preserves the existing Android prompt behavior.
+
+| Type   | Required | Platform     |
+| ------ | -------- | ------------ |
+| string | No       | iOS, Android |
 
 Example:
 

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -727,6 +727,9 @@ export interface IOSWebViewProps extends WebViewSharedProps {
    * This property specifies how to handle media capture permission requests.
    * Defaults to `prompt`, resulting in the user being prompted repeatedly.
    * Available on iOS 15 and later.
+   *
+   * Note: Android only enforces the `deny` value natively (see
+   * `AndroidWebViewProps`); other values are iOS-only.
    */
   mediaCapturePermissionGrantType?: MediaCapturePermissionGrantType;
 
@@ -1162,6 +1165,16 @@ export interface AndroidWebViewProps extends WebViewSharedProps {
    * @platform android
    */
   allowsProtectedMedia?: boolean;
+
+  /**
+   * This property specifies how to handle media capture permission requests.
+   * On Android, only `deny` is enforced natively: when set, camera/microphone
+   * requests are denied without showing a prompt or triggering an OS permission
+   * dialog. Any other value (including the default `prompt`) preserves the
+   * existing Android prompt behavior.
+   * @platform android
+   */
+  mediaCapturePermissionGrantType?: MediaCapturePermissionGrantType;
 
   /**
    * Function that is invoked when the `WebView` receives an SSL error for a sub-resource.


### PR DESCRIPTION
Android previously ignored the `mediaCapturePermissionGrantType` prop in the dApp browser WebView fork — the native setter was a no-op. Implement the minimal native enforcement the dApp browser contract needs:

- Persist the prop value in RNCWebChromeClient and propagate it through both the new- and old-architecture managers and RNCWebViewManagerImpl.
- Short-circuit RNCWebChromeClient.onPermissionRequest for `deny`: call request.deny() and return before reading requested resources, showing the site-attributed AlertDialog, or triggering an OS CAMERA/RECORD_AUDIO request.
- Any other value (including the default prompt) preserves existing Android behavior; iOS behavior is unchanged.
- Add a JVM unit test proving the deny short-circuit, plus the JUnit/Mockito test deps and testOptions to run it.
- Expose the prop on AndroidWebViewProps, update docs, and add a changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Android support for configuring how media capture permission requests are handled.
  * The `deny` option now blocks camera/microphone prompts on Android, while other values keep the existing prompt behavior.

* **Documentation**
  * Clarified platform support and behavior for media capture permission settings.

* **Tests**
  * Added coverage for denied requests and for preserving the existing prompt flow in other cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->