### PR TITLE
fix(android): honor media capture deny policy

### DIFF
--- a/.changeset/harden-android-media-capture.md
+++ b/.changeset/harden-android-media-capture.md
@@ -1,0 +1,8 @@
+---
+"@phantom/react-native-webview": patch
+---
+
+Honor `mediaCapturePermissionGrantType="deny"` on Android by rejecting camera
+and microphone resources before the existing permission flow can display a
+prompt. Other permission resources and grant-type values retain their current
+behavior.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -107,4 +107,6 @@ dependencies {
     implementation 'com.facebook.react:react-native:+'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${safeExtGet('kotlinVersion')}"
     implementation "androidx.webkit:webkit:${safeExtGet('webkitVersion')}"
+
+    testImplementation "junit:junit:4.13.2"
 }

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCMediaCapturePermission.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCMediaCapturePermission.java
@@ -1,0 +1,31 @@
+package com.reactnativecommunity.webview;
+
+import android.webkit.PermissionRequest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+final class RNCMediaCapturePermission {
+    private static final String GRANT_TYPE_DENY = "deny";
+
+    private RNCMediaCapturePermission() {}
+
+    static String[] filterRequestedResources(String grantType, String[] resources) {
+        if (!GRANT_TYPE_DENY.equals(grantType)) {
+            return resources;
+        }
+
+        List<String> filteredResources = new ArrayList<>(resources.length);
+        for (String resource : resources) {
+            if (!isMediaCaptureResource(resource)) {
+                filteredResources.add(resource);
+            }
+        }
+        return filteredResources.toArray(new String[0]);
+    }
+
+    private static boolean isMediaCaptureResource(String resource) {
+        return PermissionRequest.RESOURCE_AUDIO_CAPTURE.equals(resource)
+            || PermissionRequest.RESOURCE_VIDEO_CAPTURE.equals(resource);
+    }
+}

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java
@@ -162,7 +162,12 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
         // Permissions that we need to ask permission for from the OS
         requestedAndroidPermissions = new ArrayList<>();
 
-        for (String requestedResource : request.getResources()) {
+        String[] requestedResources = RNCMediaCapturePermission.filterRequestedResources(
+            mWebView.getMediaCapturePermissionGrantType(),
+            request.getResources()
+        );
+
+        for (String requestedResource : requestedResources) {
             String androidPermission = null;
             String requestPermissionIdentifier = null;
 

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java
@@ -167,6 +167,13 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
             request.getResources()
         );
 
+        if (requestedResources.length == 0) {
+            permissionRequest = null;
+            grantedPermissions = null;
+            request.deny();
+            return;
+        }
+
         for (String requestedResource : requestedResources) {
             String androidPermission = null;
             String requestPermissionIdentifier = null;

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
@@ -80,6 +80,7 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
     protected ProgressChangedFilter progressChangedFilter;
     protected boolean mActive = true;
     protected @Nullable String mLastCommittedUrl;
+    protected @Nullable String mMediaCapturePermissionGrantType;
 
     /**
      * WebView must be created with an context of the current activity
@@ -263,6 +264,14 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
 
     public @Nullable String getLastCommittedUrl() {
         return this.mLastCommittedUrl;
+    }
+
+    public void setMediaCapturePermissionGrantType(@Nullable String value) {
+        this.mMediaCapturePermissionGrantType = value;
+    }
+
+    public @Nullable String getMediaCapturePermissionGrantType() {
+        return this.mMediaCapturePermissionGrantType;
     }
 
     @SuppressLint("RestrictedApi")

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
@@ -582,6 +582,10 @@ class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
         view.settings.setGeolocationEnabled(value)
     }
 
+    fun setMediaCapturePermissionGrantType(viewWrapper: RNCWebViewWrapper, value: String?) {
+        viewWrapper.webView.setMediaCapturePermissionGrantType(value)
+    }
+
     fun setLackPermissionToDownloadMessage(value: String?) {
         mLackPermissionToDownloadMessage = value
     }

--- a/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -95,6 +95,12 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
     }
 
     @Override
+    @ReactProp(name = "mediaCapturePermissionGrantType")
+    public void setMediaCapturePermissionGrantType(RNCWebViewWrapper view, @Nullable String value) {
+        mRNCWebViewManagerImpl.setMediaCapturePermissionGrantType(view, value);
+    }
+
+    @Override
     @ReactProp(name = "androidLayerType")
     public void setAndroidLayerType(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setAndroidLayerType(view, value);
@@ -422,9 +428,6 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
 
     @Override
     public void setHasOnFileDownload(RNCWebViewWrapper view, boolean value) {}
-
-    @Override
-    public void setMediaCapturePermissionGrantType(RNCWebViewWrapper view, @Nullable String value) {}
 
     @Override
     public void setFraudulentWebsiteWarningEnabled(RNCWebViewWrapper view, boolean value) {}

--- a/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -72,6 +72,11 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper> {
         mRNCWebViewManagerImpl.setAllowsProtectedMedia(view, value);
     }
 
+    @ReactProp(name = "mediaCapturePermissionGrantType")
+    public void setMediaCapturePermissionGrantType(RNCWebViewWrapper view, @Nullable String value) {
+        mRNCWebViewManagerImpl.setMediaCapturePermissionGrantType(view, value);
+    }
+
     @ReactProp(name = "androidLayerType")
     public void setAndroidLayerType(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setAndroidLayerType(view, value);

--- a/android/src/test/java/com/reactnativecommunity/webview/RNCMediaCapturePermissionTest.java
+++ b/android/src/test/java/com/reactnativecommunity/webview/RNCMediaCapturePermissionTest.java
@@ -1,0 +1,46 @@
+package com.reactnativecommunity.webview;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertSame;
+
+import android.webkit.PermissionRequest;
+
+import org.junit.Test;
+
+public class RNCMediaCapturePermissionTest {
+    @Test
+    public void denyRemovesCameraAndMicrophoneResources() {
+        String[] resources = {
+            PermissionRequest.RESOURCE_VIDEO_CAPTURE,
+            PermissionRequest.RESOURCE_AUDIO_CAPTURE,
+        };
+
+        assertArrayEquals(
+            new String[0],
+            RNCMediaCapturePermission.filterRequestedResources("deny", resources)
+        );
+    }
+
+    @Test
+    public void denyPreservesUnrelatedResources() {
+        String[] resources = {
+            PermissionRequest.RESOURCE_VIDEO_CAPTURE,
+            PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID,
+        };
+
+        assertArrayEquals(
+            new String[] { PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID },
+            RNCMediaCapturePermission.filterRequestedResources("deny", resources)
+        );
+    }
+
+    @Test
+    public void otherPoliciesPreserveExistingBehavior() {
+        String[] resources = { PermissionRequest.RESOURCE_VIDEO_CAPTURE };
+
+        assertSame(
+            resources,
+            RNCMediaCapturePermission.filterRequestedResources("prompt", resources)
+        );
+    }
+}

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -1537,9 +1537,11 @@ Possible values:
 
 Note that a grant may still result in a prompt, for example if the user has never been prompted for the permission before.
 
-| Type   | Required | Platform |
-| ------ | -------- | -------- |
-| string | No       | iOS      |
+On Android, `deny` blocks camera and microphone requests without showing a WebView or operating-system permission prompt. Other values preserve the existing prompt behavior.
+
+| Type   | Required | Platform     |
+| ------ | -------- | ------------ |
+| string | No       | iOS, Android |
 
 Example:
 

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -1164,6 +1164,15 @@ export interface AndroidWebViewProps extends WebViewSharedProps {
   allowsProtectedMedia?: boolean;
 
   /**
+   * This property specifies how to handle media capture permission requests.
+   * On Android, `deny` blocks camera and microphone requests without showing
+   * a WebView or operating-system permission prompt. Other values preserve the
+   * existing prompt behavior.
+   * @platform android
+   */
+  mediaCapturePermissionGrantType?: MediaCapturePermissionGrantType;
+
+  /**
    * Function that is invoked when the `WebView` receives an SSL error for a sub-resource.
    *
    * @param event


### PR DESCRIPTION
Honor `mediaCapturePermissionGrantType="deny"` on Android.

- Remove camera and microphone resources before existing permission handling.
- Preserve protected-media requests and all other policy values.
- Wire both native architectures and add focused unit coverage.

Tests: `yarn lint`, existing Jest suite, focused Java policy harness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Android support for the `mediaCapturePermissionGrantType` WebView prop.
  * When set to `deny`, camera and microphone capture requests are blocked without showing permission prompts.
  * Other grant-type values keep existing permission behavior.
* **Documentation**
  * Updated reference docs and TypeScript prop definitions to include Android behavior and the new option.
* **Bug Fixes**
  * Hardened Android handling so denied media-capture requests don’t reach the permission prompt flow.
* **Tests**
  * Added unit tests covering `deny` vs non-`deny` behavior for media-capture resources.
* **Chores**
  * Added JUnit test dependency for Android tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->