### PR TITLE
chore: sign Version Packages automation commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba
         with:
           publish: yarn release
+          commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN_PHANTOM_SECURITY_BOT }}


### PR DESCRIPTION
## Summary

- switch the Changesets automation from Git CLI commits to the GitHub API
- ensure generated Version Packages commits and tags are GPG-signed by GitHub

## Validation

- `actionlint -ignore 'setup-node@v3' .github/workflows/release.yml`
- `git diff --check`

The ignored `setup-node@v3` actionlint finding predates this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release process by updating how release changes are committed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->