### PR TITLE
ci: publish to npm via Trusted Publishing (OIDC) [FEPLAT-5048]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,21 @@
 name: Release
 
+# Opens the "Version Packages" pull request, and publishes
+# @phantom/react-native-webview to npm once that pull request merges.
+#
+# Publishing uses npm Trusted Publishing (keyless OIDC), so there is no npm
+# token. Security registers the trusted publisher against this repository and
+# this workflow file name, so do not rename this file. Changesets shells out to
+# npm for the publish, and only npm >= 11.5.1 can make the OIDC exchange.
+#
+# Use the manual trigger to retry a publish that failed for an already merged
+# version.
+
 on:
   push:
     branches:
       - master
+  workflow_dispatch: {}
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -14,21 +26,29 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Enable Corepack
         run: corepack enable
 
       - name: Setup Node.js 20.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20.x
+
+      # Node 20 ships npm 10.x, which has no Trusted Publishing support. Same
+      # version phantom/libs pins.
+      - name: Install the npm version that supports Trusted Publishing
+        run: npm install --global npm@11.5.1
 
       - name: Install Dependencies
         run: yarn
 
+      # No NPM_TOKEN: npm exchanges the GitHub OIDC token through the trusted
+      # publisher.
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba
@@ -37,4 +57,3 @@ jobs:
           commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN_PHANTOM_SECURITY_BOT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,16 +16,12 @@ on:
     branches:
       - master
   workflow_dispatch: {}
-  # TEMPORARY, REMOVE BEFORE MERGE. It runs the trusted-publishing probe jobs
-  # below on the pull request. The publish job never runs for this event.
-  pull_request: {}
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   release:
     name: Release
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -66,47 +62,3 @@ jobs:
           # unauthenticated and reports only E404 on PUT. Verbose logging turns a
           # future failure into a readable cause.
           NPM_CONFIG_LOGLEVEL: verbose
-
-  # TEMPORARY, REMOVE BEFORE MERGE.
-  #
-  # Runs the release job's own setup, then a dry-run publish. `npm publish`
-  # performs the OIDC exchange before it checks the dry-run flag (npm 11.5.1,
-  # lib/commands/publish.js line 141), so this proves the exchange works from
-  # this workflow file, with this npm version, in this installed workspace, and
-  # it uploads nothing.
-  probe-publish-auth:
-    name: Probe publish auth (dry run)
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Setup Node.js 20.x
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 20.x
-
-      - name: Install the npm version that supports Trusted Publishing
-        run: npm install --global npm@11.5.1
-
-      - name: Install Dependencies
-        run: yarn
-
-      - name: Dry-run publish and report the OIDC outcome
-        run: |
-          echo "npm $(npm --version) at $(command -v npm)"
-          npm publish --dry-run --loglevel verbose > publish.log 2>&1 || true
-          grep -iE "oidc|provenance|E404|Unauthorized|token" publish.log || true
-          echo "--- verdict ---"
-          if grep -q "Successfully retrieved and set token" publish.log; then
-            echo "OIDC exchange succeeded. The real publish will authenticate."
-          else
-            echo "OIDC exchange did NOT succeed. Do not merge yet."
-            exit 1
-          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
     name: Release
+    # A manual run publishes whatever version the selected ref holds, so accept
+    # master only. The job is skipped for any other ref.
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,6 @@ on:
     branches:
       - master
   workflow_dispatch: {}
-  # TEMPORARY, REMOVE BEFORE MERGE. Runs the dry-run probe job below.
-  pull_request: {}
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -49,7 +47,7 @@ jobs:
         with:
           node-version: 22.x
 
-      # Node 20 ships npm 10.x, which has no Trusted Publishing support. Same
+      # Node 22 ships npm 10.x, which has no Trusted Publishing support. Same
       # version phantom/libs pins.
       - name: Install the npm version that supports Trusted Publishing
         run: npm install --global npm@11.5.1
@@ -72,45 +70,3 @@ jobs:
           # unauthenticated and reports only E404 on PUT. Verbose logging turns a
           # future failure into a readable cause.
           NPM_CONFIG_LOGLEVEL: verbose
-
-  # TEMPORARY, REMOVE BEFORE MERGE. Proves the publish authenticates on this
-  # Node version. `npm publish` runs the OIDC exchange before it honors
-  # --dry-run, so this uploads nothing.
-  probe-publish-auth:
-    name: Probe publish auth (dry run)
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-        with:
-          persist-credentials: false
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Setup Node.js 22.x
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 22.x
-
-      - name: Install the npm version that supports Trusted Publishing
-        run: npm install --global npm@11.5.1
-
-      - name: Install Dependencies
-        run: yarn
-
-      - name: Dry-run publish and report the OIDC outcome
-        run: |
-          echo "node $(node --version), npm $(npm --version) at $(command -v npm)"
-          npm publish --dry-run --loglevel verbose > publish.log 2>&1 || true
-          grep -iE "oidc|provenance|E404|Unauthorized" publish.log || true
-          echo "--- verdict ---"
-          if grep -q "Successfully retrieved and set token" publish.log; then
-            echo "OIDC exchange succeeded on this Node version."
-          else
-            echo "OIDC exchange did NOT succeed. Do not merge yet."
-            exit 1
-          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,16 @@ on:
     branches:
       - master
   workflow_dispatch: {}
+  # TEMPORARY, REMOVE BEFORE MERGE. It runs the trusted-publishing probe jobs
+  # below on the pull request. The publish job never runs for this event.
+  pull_request: {}
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   release:
     name: Release
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -57,3 +61,85 @@ jobs:
           commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # TEMPORARY, REMOVE BEFORE MERGE.
+  #
+  # These two jobs answer one question that the npm web UI can otherwise only
+  # answer to Security: which trusted-publisher configuration does npm expect
+  # for this package? They perform only the OIDC token exchange that
+  # `npm publish` performs internally. They publish nothing.
+  #
+  # npm matches the workflow file name from the OIDC claims, so the probe has to
+  # live in this file to be a fair test. The only difference between the two jobs
+  # is the GitHub environment, because that is the one claim no previous attempt
+  # ever set.
+  #
+  # npm's exchange failure path is silent by design: lib/utils/oidc.js logs at
+  # verbose and returns undefined, so `npm publish` continues unauthenticated and
+  # reports E404 on PUT. These jobs print the real error instead.
+  probe-without-environment:
+    name: Probe trusted publishing (no environment)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Exchange the OIDC token with npm
+        env:
+          ESCAPED_PACKAGE_NAME: "@phantom%2freact-native-webview"
+        run: |
+          ID_TOKEN=$(curl -sS -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=npm:registry.npmjs.org" | jq -r .value)
+          echo "::add-mask::$ID_TOKEN"
+          echo "--- claims this job presents to npm ---"
+          ID_TOKEN="$ID_TOKEN" node -e '
+            const [, payload] = process.env.ID_TOKEN.split(".");
+            const claims = JSON.parse(Buffer.from(payload, "base64url").toString());
+            const keep = ["sub", "repository", "repository_visibility", "job_workflow_ref", "environment"];
+            console.log(JSON.stringify(Object.fromEntries(keep.map(k => [k, claims[k]])), null, 2));
+          '
+          echo "--- exchange response ---"
+          STATUS=$(curl -sS -o body.json -w '%{http_code}' -X POST \
+            -H "Authorization: Bearer $ID_TOKEN" \
+            "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/$ESCAPED_PACKAGE_NAME")
+          echo "HTTP $STATUS"
+          # A 200 body holds a publish token, so never print it.
+          if [ "$STATUS" = "200" ]; then
+            echo "Exchange succeeded for this workflow file with no environment."
+          else
+            jq -r '.message // .error // .' body.json
+          fi
+
+  probe-with-ci-environment:
+    name: Probe trusted publishing (environment ci)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    environment: ci
+    permissions:
+      id-token: write
+    steps:
+      - name: Exchange the OIDC token with npm
+        env:
+          ESCAPED_PACKAGE_NAME: "@phantom%2freact-native-webview"
+        run: |
+          ID_TOKEN=$(curl -sS -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=npm:registry.npmjs.org" | jq -r .value)
+          echo "::add-mask::$ID_TOKEN"
+          echo "--- claims this job presents to npm ---"
+          ID_TOKEN="$ID_TOKEN" node -e '
+            const [, payload] = process.env.ID_TOKEN.split(".");
+            const claims = JSON.parse(Buffer.from(payload, "base64url").toString());
+            const keep = ["sub", "repository", "repository_visibility", "job_workflow_ref", "environment"];
+            console.log(JSON.stringify(Object.fromEntries(keep.map(k => [k, claims[k]])), null, 2));
+          '
+          echo "--- exchange response ---"
+          STATUS=$(curl -sS -o body.json -w '%{http_code}' -X POST \
+            -H "Authorization: Bearer $ID_TOKEN" \
+            "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/$ESCAPED_PACKAGE_NAME")
+          echo "HTTP $STATUS"
+          # A 200 body holds a publish token, so never print it.
+          if [ "$STATUS" = "200" ]; then
+            echo "Exchange succeeded for this workflow file with environment ci."
+          else
+            jq -r '.message // .error // .' body.json
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,85 +61,52 @@ jobs:
           commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # npm's OIDC exchange fails silently by design: lib/utils/oidc.js logs
+          # at verbose and returns undefined, then the publish continues
+          # unauthenticated and reports only E404 on PUT. Verbose logging turns a
+          # future failure into a readable cause.
+          NPM_CONFIG_LOGLEVEL: verbose
 
   # TEMPORARY, REMOVE BEFORE MERGE.
   #
-  # These two jobs answer one question that the npm web UI can otherwise only
-  # answer to Security: which trusted-publisher configuration does npm expect
-  # for this package? They perform only the OIDC token exchange that
-  # `npm publish` performs internally. They publish nothing.
-  #
-  # npm matches the workflow file name from the OIDC claims, so the probe has to
-  # live in this file to be a fair test. The only difference between the two jobs
-  # is the GitHub environment, because that is the one claim no previous attempt
-  # ever set.
-  #
-  # npm's exchange failure path is silent by design: lib/utils/oidc.js logs at
-  # verbose and returns undefined, so `npm publish` continues unauthenticated and
-  # reports E404 on PUT. These jobs print the real error instead.
-  probe-without-environment:
-    name: Probe trusted publishing (no environment)
+  # Runs the release job's own setup, then a dry-run publish. `npm publish`
+  # performs the OIDC exchange before it checks the dry-run flag (npm 11.5.1,
+  # lib/commands/publish.js line 141), so this proves the exchange works from
+  # this workflow file, with this npm version, in this installed workspace, and
+  # it uploads nothing.
+  probe-publish-auth:
+    name: Probe publish auth (dry run)
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
     steps:
-      - name: Exchange the OIDC token with npm
-        env:
-          ESCAPED_PACKAGE_NAME: "@phantom%2freact-native-webview"
-        run: |
-          ID_TOKEN=$(curl -sS -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=npm:registry.npmjs.org" | jq -r .value)
-          echo "::add-mask::$ID_TOKEN"
-          echo "--- claims this job presents to npm ---"
-          ID_TOKEN="$ID_TOKEN" node -e '
-            const [, payload] = process.env.ID_TOKEN.split(".");
-            const claims = JSON.parse(Buffer.from(payload, "base64url").toString());
-            const keep = ["sub", "repository", "repository_visibility", "job_workflow_ref", "environment"];
-            console.log(JSON.stringify(Object.fromEntries(keep.map(k => [k, claims[k]])), null, 2));
-          '
-          echo "--- exchange response ---"
-          STATUS=$(curl -sS -o body.json -w '%{http_code}' -X POST \
-            -H "Authorization: Bearer $ID_TOKEN" \
-            "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/$ESCAPED_PACKAGE_NAME")
-          echo "HTTP $STATUS"
-          # A 200 body holds a publish token, so never print it.
-          if [ "$STATUS" = "200" ]; then
-            echo "Exchange succeeded for this workflow file with no environment."
-          else
-            jq -r '.message // .error // .' body.json
-          fi
+      - name: Checkout Repo
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-  probe-with-ci-environment:
-    name: Probe trusted publishing (environment ci)
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    environment: ci
-    permissions:
-      id-token: write
-    steps:
-      - name: Exchange the OIDC token with npm
-        env:
-          ESCAPED_PACKAGE_NAME: "@phantom%2freact-native-webview"
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 20.x
+
+      - name: Install the npm version that supports Trusted Publishing
+        run: npm install --global npm@11.5.1
+
+      - name: Install Dependencies
+        run: yarn
+
+      - name: Dry-run publish and report the OIDC outcome
         run: |
-          ID_TOKEN=$(curl -sS -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=npm:registry.npmjs.org" | jq -r .value)
-          echo "::add-mask::$ID_TOKEN"
-          echo "--- claims this job presents to npm ---"
-          ID_TOKEN="$ID_TOKEN" node -e '
-            const [, payload] = process.env.ID_TOKEN.split(".");
-            const claims = JSON.parse(Buffer.from(payload, "base64url").toString());
-            const keep = ["sub", "repository", "repository_visibility", "job_workflow_ref", "environment"];
-            console.log(JSON.stringify(Object.fromEntries(keep.map(k => [k, claims[k]])), null, 2));
-          '
-          echo "--- exchange response ---"
-          STATUS=$(curl -sS -o body.json -w '%{http_code}' -X POST \
-            -H "Authorization: Bearer $ID_TOKEN" \
-            "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/$ESCAPED_PACKAGE_NAME")
-          echo "HTTP $STATUS"
-          # A 200 body holds a publish token, so never print it.
-          if [ "$STATUS" = "200" ]; then
-            echo "Exchange succeeded for this workflow file with environment ci."
+          echo "npm $(npm --version) at $(command -v npm)"
+          npm publish --dry-run --loglevel verbose > publish.log 2>&1 || true
+          grep -iE "oidc|provenance|E404|Unauthorized|token" publish.log || true
+          echo "--- verdict ---"
+          if grep -q "Successfully retrieved and set token" publish.log; then
+            echo "OIDC exchange succeeded. The real publish will authenticate."
           else
-            jq -r '.message // .error // .' body.json
+            echo "OIDC exchange did NOT succeed. Do not merge yet."
+            exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ on:
     branches:
       - master
   workflow_dispatch: {}
+  # TEMPORARY, REMOVE BEFORE MERGE. Runs the dry-run probe job below.
+  pull_request: {}
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -33,14 +35,19 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          # changesets runs with commitMode: github-api, so the version commit
+          # and the tag both go through Octokit. No step needs local git auth.
+          persist-credentials: false
 
       - name: Enable Corepack
         run: corepack enable
 
-      - name: Setup Node.js 20.x
+      # npm documents Node >= 22.14.0 for Trusted Publishing.
+      - name: Setup Node.js 22.x
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20.x
+          node-version: 22.x
 
       # Node 20 ships npm 10.x, which has no Trusted Publishing support. Same
       # version phantom/libs pins.
@@ -65,3 +72,45 @@ jobs:
           # unauthenticated and reports only E404 on PUT. Verbose logging turns a
           # future failure into a readable cause.
           NPM_CONFIG_LOGLEVEL: verbose
+
+  # TEMPORARY, REMOVE BEFORE MERGE. Proves the publish authenticates on this
+  # Node version. `npm publish` runs the OIDC exchange before it honors
+  # --dry-run, so this uploads nothing.
+  probe-publish-auth:
+    name: Probe publish auth (dry run)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node.js 22.x
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22.x
+
+      - name: Install the npm version that supports Trusted Publishing
+        run: npm install --global npm@11.5.1
+
+      - name: Install Dependencies
+        run: yarn
+
+      - name: Dry-run publish and report the OIDC outcome
+        run: |
+          echo "node $(node --version), npm $(npm --version) at $(command -v npm)"
+          npm publish --dry-run --loglevel verbose > publish.log 2>&1 || true
+          grep -iE "oidc|provenance|E404|Unauthorized" publish.log || true
+          echo "--- verdict ---"
+          if grep -q "Successfully retrieved and set token" publish.log; then
+            echo "OIDC exchange succeeded on this Node version."
+          else
+            echo "OIDC exchange did NOT succeed. Do not merge yet."
+            exit 1
+          fi

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/phantom/react-native-webview.git"
+    "url": "git+https://github.com/phantom/react-native-webview.git"
   },
   "files": [
     "android/src",


### PR DESCRIPTION
The 1.2.4 publish fails with `E404 Not Found - PUT .../@phantom%2freact-native-webview`, so two merged Android security fixes never reached npm and the wallet app still ships 1.2.3. npm's OIDC exchange needs npm >= 11.5.1 and `id-token: write`. Node 20 ships npm 10.x, so the job fell back to `NPM_PUBLISH_TOKEN_PHANTOM_SECURITY_BOT`, created 26 Jan for 90 days and dead since April.

- **release.yml**: install npm 11.5.1, grant `id-token: write`, drop the npm token. Verified on this PR before merge, not assumed: the token exchange returns `HTTP 201`, and a dry-run publish logs `npm verbose oidc Successfully retrieved and set token`. Nothing was uploaded, since npm runs the exchange before it honors `--dry-run`. No npm-side change is needed - the trusted publisher already accepts this workflow file, with or without a GitHub environment.
- **release.yml**: `NPM_CONFIG_LOGLEVEL: verbose`. npm's `oidc()` never throws; it logs at verbose and returns `undefined`, then the publish continues unauthenticated and reports only E404. That silence is why the January debugging never found a cause. Also adds `workflow_dispatch` to retry a publish for an already merged version such as 1.2.4, and moves setup-node off v3, which actionlint rejects as too old for current runners.
- **package.json**: `repository.url` needs the `git+` prefix, which provenance validation under trusted publishing expects.

After merge, the push to master should publish 1.2.4 and tag it. The token secret and its bypass-2FA npm token can then be deleted; npm is deprecating that token class anyway.

Pre-existing and unrelated: iOS CI fails on this branch, and it failed the same way on the first push before any of these CI changes.
