### PR TITLE
ci: unbreak the iOS and Android test-app builds [FEPLAT-5048]

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -23,12 +23,12 @@ jobs:
       - name: Install Pods
         run: ${{matrix.extraEnv}} pod install
         working-directory: example/ios
+      # The job builds and never boots the app, so it takes the generic
+      # simulator destination. Naming one device tied this job to whichever
+      # simulators the runner image happened to ship, and it broke when
+      # `iPhone 16` left the image.
       - name: Build iOS test app
         run: |
-          device_name='iPhone 16'
-          device=$(xcrun simctl list devices "${device_name}" available | grep "${device_name} (")
-          re='\(([-0-9A-Fa-f]+)\)'
-          [[ $device =~ $re ]] || exit 1
-          xcodebuild -workspace WebviewExample.xcworkspace -scheme ReactTestApp -destination "platform=iOS Simulator,id=${BASH_REMATCH[1]}" CODE_SIGNING_ALLOWED=NO COMPILER_INDEX_STORE_ENABLE=NO build
+          xcodebuild -workspace WebviewExample.xcworkspace -scheme ReactTestApp -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO COMPILER_INDEX_STORE_ENABLE=NO build
         working-directory: example/ios
     timeout-minutes: 60

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -11,7 +11,7 @@
 # particularly useful for configuring JVM memory settings for build performance.
 # This does not affect the JVM settings for the Gradle client VM.
 # The default is `-Xmx512m -XX:MaxMetaspaceSize=256m`.
-org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # When configured, Gradle will fork up to org.gradle.workers.max JVMs to execute
 # projects in parallel. To learn more about parallel task execution, see the
@@ -24,8 +24,12 @@ org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryEr
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
-# Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
+# Automatically convert third-party libraries to use AndroidX. React Native 0.73
+# and its dependencies are AndroidX already, and the conversion rewrites every
+# class of every AAR, which is what ran the build out of heap. Run
+# `./gradlew checkJetifier` if a future dependency looks like it needs the
+# conversion back.
+android.enableJetifier=false
 
 # Version of Flipper to use with React Native. Default value is whatever React
 # Native defaults to. To disable Flipper, set it to `false`.


### PR DESCRIPTION
Both jobs fail on `master` today, so every pull request opens with red checks and a real regression would not stand out. PR #52 is the case in point: four red Android checks and two red iOS checks, none of them caused by that diff.

- **iOS**: the build step resolved the simulator UDID for a hardcoded `iPhone 16` and exited 1 when the grep found nothing, which is what happens now that the runner image dropped that device. The job only builds and never boots the app, so it takes `-destination 'generic/platform=iOS Simulator'` and stops depending on the image's simulator list.
- **Android**: `JetifyTransform` ran out of heap on `hermes-android-0.73.5-debug.aar`. Jetifier rewrites every class of every AAR, and React Native 0.73 and its dependencies are AndroidX already, so the conversion is now off. Heap also goes 2g to 4g, because one OOM cancels the whole four-job matrix.

The checks on this PR are the verification: a dependency that genuinely still needed jetifier would fail here with unresolved `android.support.*` classes, and the fallback would be to keep `enableJetifier=true` and rely on the larger heap alone.

Two follow-ups deliberately left out: `gradle/gradle-build-action@v2` is deprecated in favour of `actions/setup-gradle`, and #51 pins action SHAs across every workflow, so it will touch `ios-ci.yml` too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved iOS CI builds by using a generic simulator destination instead of requiring a specific simulator model.
  * Increased available memory for Android build processes to improve build reliability.
  * Updated Android compatibility settings and added a fallback check for legacy support requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->